### PR TITLE
Food Create Endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+config

--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -18,4 +18,19 @@ router.get('/:id', function(req, res, next) {
   });
 });
 
+router.post('/', function(req, res, next) {
+  Food.create({
+    name: req.body.name,
+    calories: req.body.calories
+  })
+  .then(food => {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(201).send(JSON.stringify(food));
+  })
+  .catch(error => {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(500).send({error});
+  });
+});
+
 module.exports = router;

--- a/seeders/20190820000918-food_seed.js
+++ b/seeders/20190820000918-food_seed.js
@@ -3,14 +3,12 @@
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.bulkInsert('Food', [{
-      id: 1,
       name: 'Banana',
       calories: 150,
       createdAt: new Date(),
       updatedAt: new Date()
     },
     {
-      id: 2,
       name: 'Mint',
       calories: 14,
       createdAt: new Date(),
@@ -19,6 +17,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.bulkDelete('Foods', null, {})
+    return queryInterface.bulkDelete('Food', null, {})
   }
 };

--- a/test/food.spec.js
+++ b/test/food.spec.js
@@ -21,13 +21,24 @@ describe('api', () => {
   });
 
   describe('Test food path', () => {
-    test('It can get a single food from the database', async () => {
-       await agent.get('/api/v1/foods/1').then(response => {
+    test('It can get a single food from the database', () => {
+      return request(app).get('/api/v1/foods/1').then(response => {
         expect(response.statusCode).toBe(200)
         expect(response.body.id).toBe(1)
         expect(response.body.name).toBe('Banana')
         expect(response.body.calories).toBe(150)
       })
     });
+
+    test('It can create a new food in the database', () => {
+      return request(app).post('/api/v1/foods')
+        .send('name=Test&calories=100')
+        .then(response => {
+          expect(response.statusCode).toBe(201)
+          expect(response.body.id).toBeGreaterThan(0)
+          expect(response.body.name).toBe('Test')
+          expect(response.body.calories).toBe(100)
+        })
+    })
   });
 });


### PR DESCRIPTION
This PR brings in the functionality to Create a new Food resource in the database by using the `api/v1/foods` endpoint, sending a POST request. The POST request requires a body containing the information for a Food resource, as follows:
```
food: 'name',
calories: number
```
This test found that having `async` and `await` on the test did not help/change anything, so we removed it from our previous test as well.

This PR also `.gitignores` the Config folder containing our `config.json` file to ensure that TravisCI will consistently have the correct information to set up our database and run our tests. This also makes cloning the repo to new machines easier, as all that will need to be done is change the setup information on the local machine to follow the DB User and Pass.
We ran into an issue with our Foods Seeder as well, as there were ID collisions depending on how we ran our tests. Since the Seeder file contained specific IDs for the new Food resources, if the Table was not correctly cleared, the Seeder process would fail and throw errors during testing.
Additionally, the `down` process for the Seeder was referring to the incorrect resources of `Foods`, but Sequelize pluralizes `Food` as `Food` instead.

resolves #3 