### PR TITLE
Edit food endpoint

### DIFF
--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -45,4 +45,21 @@ router.post('/', function(req, res, next) {
   });
 });
 
+router.patch('/:id', function (req, res, next) {
+ Food.update(
+   {name: req.body.name, calories: req.body.calories},
+   {where: {id: req.params.id}})
+ .then(row => {
+   Food.findOne({where: {id: req.params.id}})
+   .then(food => {
+     res.setHeader('Content-Type', 'application/json');
+     res.status(201).send(JSON.stringify(food));
+   })
+ })
+ .catch(error => {
+   res.setHeader('Content-Type', 'application/json');
+   res.status(500).send({error});
+ });
+})
+
 module.exports = router;

--- a/test/food.spec.js
+++ b/test/food.spec.js
@@ -53,15 +53,15 @@ describe('api', () => {
         })
     })
 
-    test('It can edit a food in the database'), () => {
+    test('It can edit a food in the database', () => {
       return request(app).patch('/api/v1/foods/1')
-        .send('name=Test&calories=100')
+        .send({name: 'Test', calories: 100})
         .then(response => {
           expect(response.statusCode).toBe(201)
-          expect(response.body.id).toBeGreaterThan(0)
+          expect(response.body.id).toBe(1)
           expect(response.body.name).toBe('Test')
           expect(response.body.calories).toBe(100)
         })
-      }
+      })
   });
 });

--- a/test/food.spec.js
+++ b/test/food.spec.js
@@ -52,5 +52,16 @@ describe('api', () => {
           expect(response.body.calories).toBe(100)
         })
     })
+
+    test('It can edit a food in the database'), () => {
+      return request(app).patch('/api/v1/foods/1')
+        .send('name=Test&calories=100')
+        .then(response => {
+          expect(response.statusCode).toBe(201)
+          expect(response.body.id).toBeGreaterThan(0)
+          expect(response.body.name).toBe('Test')
+          expect(response.body.calories).toBe(100)
+        })
+      }
   });
 });


### PR DESCRIPTION
This PR:
You can make a PATCH request to '/api/v1/foods/:id' with a name and calories in the body.  The food matching that id will be edited and the newly edited food will be returned.

A bit of ugliness in the promise inside of a promise to both update and then fetch the updated food, but when I attempted an alternative I found here: https://medium.com/@sarahdherr/sequelizes-update-method-example-included-39dfed6821d I couldn't get it to work 🤷‍♂ 

All tests are passing