### PR TITLE
Delete Food Endpoint

### DIFF
--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -45,4 +45,20 @@ router.post('/', function(req, res, next) {
   });
 });
 
+router.delete('/:id', function(req, res, next) {
+  Food.destroy({
+    where: {
+      id: req.params.id
+    }
+  })
+  .then(food => {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(204).send();
+  })
+  .catch(error => {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(500).send({error});
+  });
+});
+
 module.exports = router;

--- a/test/food.spec.js
+++ b/test/food.spec.js
@@ -1,6 +1,7 @@
 var shell = require('shelljs');
 var request = require("supertest");
 var app = require('../app');
+var Food = require('../models').Food
 
 describe('api', () => {
   beforeAll(() => {
@@ -51,6 +52,16 @@ describe('api', () => {
           expect(response.body.name).toBe('Test')
           expect(response.body.calories).toBe(100)
         })
+    })
+
+    test('It can delete an existing food in the database', () => {
+      return Food.create({name: 'Donut', calories: 1000, createdAt: new Date(), updatedAt: new Date()})
+      .then(food => {
+        return request(app).delete(`/api/v1/foods/${food.id}`)
+        .then(response => {
+          expect(response.statusCode).toBe(204)
+        })
+      })
     })
   });
 });


### PR DESCRIPTION
This PR brings in the functionality for the DELETE Food endpoint, following the convention of `/api/v1/foods/:id` for the request path. Sending a DELETE request to this endpoint only requires that ID in the path variable, and no other information in the body or params.
Following RESTful rules, the response to this request is a 204 No Content, providing no body to reference.
Additionally, in trying a new method of accessing resources, I have added the Food model directly to our tests. This allows us to create new Food's in the test, as opposed to relying on our Seeder file.

resolves #5 