### PR TITLE
Hotfix Sequelize Index.js

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -10,7 +10,7 @@ const db = {};
 
 let sequelize;
 if (config.use_env_variable) {
-  sequelize = new Sequelize(process.env[config.use_env_variable], config);
+  sequelize = new Sequelize(config.use_env_variable, config);
 } else {
   sequelize = new Sequelize(config.database, config.username, config.password, config);
 }


### PR DESCRIPTION
Hotfix Sequelize Index.js file to not call a nested process.env.process.env.DATABASE_URL for the PostgresDB on Heroku.

That's right. Sequelize tries to called the value of your `config.js` to then access the value in `process.env`. Not great.