### PR TITLE
Revert to config.js production.use_env_variable: 'DATABASE_URL'

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -22,6 +22,6 @@ module.exports = {
     host: "127.0.0.1",
     dialect: "postgres",
     operatorsAliases: false,
-    use_env_variable: process.env.DATABASE_URL
+    use_env_variable: "DATABASE_URL"
   }
 }

--- a/models/index.js
+++ b/models/index.js
@@ -10,7 +10,7 @@ const db = {};
 
 let sequelize;
 if (config.use_env_variable) {
-  sequelize = new Sequelize(config.use_env_variable, config);
+  sequelize = new Sequelize(process.env[config.use_env_variable], config);
 } else {
   sequelize = new Sequelize(config.database, config.username, config.password, config);
 }


### PR DESCRIPTION
Revert Sequelize index.js to process.env[config.use_env_variable] for Production Sequelize init

Thinking we could get around the decisions made by the Sequelize developers was a bad idea. Apparently `sequelize-cli` uses the same thought process for migrations that `sequelize` uses for initializing a Sequelize object. While I might disagree, I can't reasonable modify the modules across the two packages to follow the convention.