### PR TITLE
Testing Setup/Teardown Refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,10 @@
     "babel-jest": "^24.9.0",
     "shelljs": "^0.8.3",
     "supertest": "^4.0.2"
+  },
+  "jest": {
+    "maxConcurrency": 1,
+    "globalSetup": "./test/helper/testGlobalSetup.js",
+    "globalTeardown": "./test/helper/testGlobalTeardown.js"
   }
 }

--- a/test/helper/testCleanup.js
+++ b/test/helper/testCleanup.js
@@ -1,0 +1,3 @@
+module.exports = async function cleanup(model) {
+  await model.destroy({ where: {} })
+}

--- a/test/helper/testGlobalSetup.js
+++ b/test/helper/testGlobalSetup.js
@@ -1,0 +1,7 @@
+var shell = require('shelljs');
+
+module.exports = () => {
+  shell.exec('npx sequelize db:drop');
+  shell.exec('npx sequelize db:create');
+  shell.exec('npx sequelize db:migrate');
+}

--- a/test/helper/testGlobalTeardown.js
+++ b/test/helper/testGlobalTeardown.js
@@ -1,0 +1,5 @@
+var shell = require('shelljs');
+
+module.exports = () => {
+  shell.exec('npx sequelize db:drop');
+}


### PR DESCRIPTION
This PR brings in the refactor of our tests to ensure stability and speed. Instead of `create`, `migrate`, and `seed` a test database for every test, we now just `create` the DB before any of the tests run, and then `drop` the DB after everything runs. This allows us to only have to `clean` the DB inbetween tests, and manually Create Food items for the tests that need it.
This has reduced our test time substantially, and will now be easier to write in the future, not relying on a seeder file.
The Jest helper files are stored inside of the `test` directory, and are just simple methods that we can import to any test file in the future.

resolves #30 