### PR TITLE
Food API Edgecases

### DIFF
--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -73,20 +73,26 @@ router.delete('/:id', function(req, res, next) {
 });
 
 router.patch('/:id', function (req, res, next) {
- Food.update(
-   {name: req.body.name, calories: req.body.calories},
-   {where: {id: req.params.id}})
- .then(row => {
-   Food.findOne({where: {id: req.params.id}})
-   .then(food => {
-     res.setHeader('Content-Type', 'application/json');
-     res.status(201).send(JSON.stringify(food));
-   })
- })
- .catch(error => {
-   res.setHeader('Content-Type', 'application/json');
-   res.status(500).send({error});
- });
+  Food.findOne({where: {id: req.params.id}})
+  .then(food => {
+    if (food) {
+      food.update({
+        name: req.body.name,
+        calories: req.body.calories
+      })
+      .then(food => {
+        res.setHeader('Content-Type', 'application/json');
+        res.status(201).send(JSON.stringify(food));
+      })
+    } else {
+      res.setHeader('Content-Type', 'application/json');
+      res.status(404).send(JSON.stringify({message: 'Food not found'}));
+    }
+  })
+  .catch(error => {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(500).send({error});
+  });
 })
 
 

--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -58,8 +58,13 @@ router.delete('/:id', function(req, res, next) {
     }
   })
   .then(food => {
-    res.setHeader('Content-Type', 'application/json');
-    res.status(204).send();
+    if (food) {
+      res.setHeader('Content-Type', 'application/json');
+      res.status(204).send();
+    } else {
+      res.setHeader('Content-Type', 'application/json');
+      res.status(404).send(JSON.stringify({message: 'Food not found'}));
+    }
   })
   .catch(error => {
     res.setHeader('Content-Type', 'application/json');

--- a/test/food.spec.js
+++ b/test/food.spec.js
@@ -131,5 +131,14 @@ describe('api', () => {
         })
       })
     })
+
+    test('It can not edit a food not in the database', () => {
+      return request(app).patch(`/api/v1/foods/1`)
+      .send({name: 'Test', calories: 100})
+      .then(response => {
+        expect(response.statusCode).toBe(404)
+        expect(response.body.message).toBe('Food not found')
+      })
+    })
   });
 });

--- a/test/food.spec.js
+++ b/test/food.spec.js
@@ -107,6 +107,14 @@ describe('api', () => {
       })
     })
 
+    test('It can not delete a non-existant food in the database', () => {
+      return request(app).delete(`/api/v1/foods/1`)
+      .then(response => {
+        expect(response.statusCode).toBe(404)
+        expect(response.body.message).toBe('Food not found')
+      })
+    })
+
     test('It can edit a food in the database', () => {
       return Food.create({
         name: 'Banana',

--- a/test/food.spec.js
+++ b/test/food.spec.js
@@ -78,9 +78,17 @@ describe('api', () => {
         })
     })
 
-    test("It can't create a food in the database if missing parameters", () => {
+    test("It can't create a food in the database if missing calories parameter", () => {
       return request(app).post('/api/v1/foods')
         .send('name=Test')
+        .then(response => {
+          expect(response.statusCode).toBe(500)
+        })
+      })
+
+    test("It can't create a food in the database if missing name parameter", () => {
+      return request(app).post('/api/v1/foods')
+        .send('calories=55')
         .then(response => {
           expect(response.statusCode).toBe(500)
         })


### PR DESCRIPTION
This PR brings in some edge cases for the rest of our Foods endpoints.
- Create endpoint tests cover both missing `name` and `calories` params
- Delete endpoint test covers non-existent food (404 response)
- Update endpoint test covers non-existent food (404 response)

This also refactors the Update Food route to allow for the if logic we use to send a 404 in the case of a missing Food. 